### PR TITLE
Fixed akdb_rel_eq_assoc test

### DIFF
--- a/akdb/src/opti/rel_eq_assoc.c
+++ b/akdb/src/opti/rel_eq_assoc.c
@@ -87,7 +87,7 @@ struct list_node *AK_rel_eq_assoc(struct list_node *list_rel_eq) {
                                 qsort(cost, 3, sizeof (cost_eval), AK_compare);
 
                                 //Change inserted relation to largest table
-								Ak_dbg_messg(MIDDLE, REL_EQ, "::table_name (%s) in temp list changed to %s\n", temp_elem_prev->data, cost[2].data); 
+								Ak_dbg_messg(MIDDLE, REL_EQ, "::table_name (%s) in temp list changed to %s\n", temp_elem_prev->data, cost[2].data);
                                 temp_elem_prev->size = strlen(cost[2].data) + 1;
                                 memset(temp_elem_prev->data, '\0', MAX_VARCHAR_LENGTH);
                                 strcpy(temp_elem_prev->data, cost[2].data);
@@ -101,11 +101,11 @@ struct list_node *AK_rel_eq_assoc(struct list_node *list_rel_eq) {
                                 //Insert smallest table at the end of temp list
                                 Ak_InsertAtEnd_L3(TYPE_OPERAND, cost[0].data, strlen(cost[0].data) + 1, temp);
 								Ak_dbg_messg(MIDDLE, REL_EQ, "::table_name (%s) inserted in temp list\n", cost[0].data);
-								
+
                                 //Insert operator
 								Ak_InsertAtEnd_L3(list_elem->type, list_elem->data, list_elem->size, temp);
 								Ak_dbg_messg(MIDDLE, REL_EQ, "::operator %s inserted in temp list\n", list_elem->data);
-								
+
                                 list_elem = list_elem->next;
                             } else {
                             	Ak_InsertAtEnd_L3(list_elem->type, list_elem->data, list_elem->size, temp);
@@ -410,6 +410,77 @@ void AK_print_rel_eq_assoc(struct list_node *list_rel_eq) {
     }
     AK_EPI;
 }
+
+struct list_node *AK_get_expected_test_result() {
+    AK_PRO;
+    struct list_node *expr = (struct list_node *) AK_malloc(sizeof (struct list_node));
+    Ak_Init_L3(&expr);
+
+    Ak_InsertAtEnd_L3(TYPE_OPERATOR, "p", sizeof ("p"), expr);
+    Ak_InsertAtEnd_L3(TYPE_ATTRIBS, "L1;L2;L3;L4", sizeof ("L1;L2;L3;L4"), expr); //projection attribute
+    Ak_InsertAtEnd_L3(TYPE_OPERATOR, "p", sizeof ("p"), expr);
+    Ak_InsertAtEnd_L3(TYPE_ATTRIBS, "L1;L4;L3;L2;L5", sizeof ("L1;L4;L3;L2;L5"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERATOR, "s", sizeof ("s"), expr);
+    Ak_InsertAtEnd_L3(TYPE_CONDITION, "`L1` > 100 OR `L2` < 50", sizeof ("`L1` > 100 OR `L2` < 50"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERAND, "student", sizeof ("student"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERAND, "student", sizeof ("student"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERAND, "profesor", sizeof ("profesor"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERATOR, "u", sizeof ("u"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERATOR, "u", sizeof ("u"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERATOR, "p", sizeof ("p"), expr);
+    Ak_InsertAtEnd_L3(TYPE_ATTRIBS, "mbr;firstname;job", sizeof ("mbr;firstname;job"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERAND, "student", sizeof ("student"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERAND, "profesor", sizeof ("profesor"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERATOR, "t", sizeof ("t"), expr);
+    Ak_InsertAtEnd_L3(TYPE_CONDITION, "`mbr` = `id`", sizeof ("`mbr` = `id`"), expr); //theta join attribute
+
+    Ak_InsertAtEnd_L3(TYPE_OPERAND, "student", sizeof ("student"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERAND, "profesor", sizeof ("profesor"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERATOR, "n", sizeof ("n"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERAND, "mbr;job", sizeof ("mbr;job"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERAND, "profesor", sizeof ("profesor"), expr);
+    Ak_InsertAtEnd_L3(TYPE_OPERATOR, "n", sizeof ("n"), expr);
+    Ak_InsertAtEnd_L3(TYPE_CONDITION, "mbr;job", sizeof ("mbr;job"), expr);
+    AK_EPI;
+    return expr;
+}
+
+int AK_compare_test_results(struct list_node *expected, struct list_node *result){
+    AK_PRO;
+    struct list_node *list_elem_expected = (struct list_node *) Ak_First_L2(expected);
+    struct list_node *list_elem_result = (struct list_node *) Ak_First_L2(result);
+
+    int same = 0;
+
+    while (list_elem_expected != NULL) {
+        //if result is shorter than expected they are not the same
+        if(list_elem_result !=NULL){
+            if(strcmp(list_elem_expected->data, list_elem_result->data)==0 && list_elem_expected->type == list_elem_result->type){
+                same = 1;
+            }else{
+                same = 0;
+                break;
+            }
+
+            list_elem_result = list_elem_result->next;
+            list_elem_expected = list_elem_expected->next;
+
+        }else{
+            same = 0;
+            break;
+        }
+    }
+
+    //if result is longer than expected they are not the same
+    if(list_elem_result !=NULL){
+        same=0;
+    }
+
+    AK_EPI;
+    return same;
+}
+
+
 /**
  * @author Dino Laktašić.
  * @brief Function for testing relational equivalences regarding associativity
@@ -675,13 +746,38 @@ TestResult AK_rel_eq_assoc_test() {
     Ak_InsertAtEnd_L3(TYPE_OPERATOR, "n", sizeof ("n"), expr);
     Ak_InsertAtEnd_L3(TYPE_CONDITION, "mbr;job", sizeof ("mbr;job"), expr);
 
-    AK_print_rel_eq_assoc(AK_rel_eq_assoc(expr));
+    printf("\n------------------> BEFORE OPTIMIZATION <------------------\n\n");
+
+    AK_print_rel_eq_assoc(expr);
+
+    printf("\n------------------> AFTER OPTIMIZATION <------------------\n\n");
+
+
+    struct list_node *optiResult = AK_rel_eq_assoc(expr);
+    AK_print_rel_eq_assoc(optiResult);
+
+    printf("\n------------------> EXPECTED <------------------\n\n");
+
+    struct list_node *expectedResult = AK_get_expected_test_result();
+    AK_print_rel_eq_assoc(expectedResult);
+
 
     printf("\n------------------> TEST_ASSOCIATIVITY_FUNCTIONS <------------------\n\n");
-    printf("...");
+
+    int failedTests = 0;
+    int successfulTest = 0;
+
+    if(AK_compare_test_results(expectedResult, optiResult)==0){
+        failedTests++;
+    }else{
+        successfulTest++;
+    }
+
+    TestResult result = TEST_result(successfulTest, failedTests);
+    TEST_output_results(result);
 
     Ak_DeleteAll_L3(&expr);
 
     AK_EPI;
-    return TEST_result(0,0);
+    return result;
 }


### PR DESCRIPTION
Added comparison between expected result and result of the optimisation function.
There weren't any programmatic checks in the test before. 