### PR TITLE
Update 'Table_details_command' - crash fixed

### DIFF
--- a/akdb/src/srv/sql_executor.py
+++ b/akdb/src/srv/sql_executor.py
@@ -196,7 +196,7 @@ class Table_details_command:
 
     # execute method
     # defines what is called when table_details command is invoked
-    def execute1(self):
+    def execute(self):
         print "Printing out: "
         result = "Number of attributes: " + \
             str(ak47.AK_num_attr(self.matcher.group(1)))


### PR DESCRIPTION
Ispravak atributa 'execute1' u 'execute' što je uzrokovalo prestanak rada servera prilikom pozivanja.
Ispravljanjem i testiranjem istog, server više ne pada međutim za bilo koju tablicu javlja broj atributa i zapisa -2