### PR TITLE
Ispravci view i select #216

### DIFF
--- a/akdb/src/sql/select.c
+++ b/akdb/src/sql/select.c
@@ -25,11 +25,10 @@
  * @param srcTable - original table that is used for selection
  * @param destTable - table that contains the result
  * @param condition - condition for selection
- * @param attributes - atributes to be selected
- * @param ordering - atributes for result sorting
+ * @param attributes - attributes to be selected
+ * @param ordering - attributes for result sorting
  * @return EXIT_SUCCESS if cache result in memory and print table else break 
  */
-//int AK_select(char *srcTable,char *destTable,AK_list *attributes,AK_list *condition){
 int AK_select(char *srcTable, char *destTable, struct list_node *attributes, struct list_node *condition, struct list_node *ordering)
 {
     struct list_node *attribute;
@@ -109,7 +108,7 @@ int AK_select(char *srcTable, char *destTable, struct list_node *attributes, str
 }
 
 /**
- * @author Renata Mesaros, updatet Filip Žmuk
+ * @author Renata Mesaros, updated Filip Žmuk
  * @brief Function for testing the implementation
  */
 TestResult AK_select_test(){

--- a/akdb/src/sql/select.h
+++ b/akdb/src/sql/select.h
@@ -20,7 +20,6 @@
 
 #include "../file/table.h"
 #include "../auxi/test.h"
-#include "../file/table.h"
 #include "../file/fileio.h"
 #include "../rel/selection.h"
 #include "../rel/projection.h"

--- a/akdb/src/sql/view.c
+++ b/akdb/src/sql/view.c
@@ -20,10 +20,38 @@
 
 #include "view.h"
 
+
+/**
+ * @author Sara Kisic
+ * @brief Function that checks if the name of the view already exists in AK_view table
+ * @param name Name of the view
+ * @return EXIT_ERROR if the name already exists or name
+ */
+char* AK_check_view_name(char *name){
+	int i = 0;
+	char *result;
+    
+    struct list_node *row;
+    AK_PRO;
+    
+    while ((row = (struct list_node*)AK_get_row(i++, "AK_view"))) {
+        struct list_node *name_elem = AK_GetNth_L2(2,row);
+        if (strcmp(name_elem->data, name) == 0) {
+            result = (char*)(EXIT_ERROR);
+            break;
+        }
+        else{
+            result = name;
+        }
+    }
+    AK_EPI;
+    return result;
+}
+
 /**
  * @author Kresimir Ivkovic
  * @brief Function that finds an object's id by its name
- * @param name name of the view
+ * @param name Name of the view
  * @return View's id or EXIT_ERROR
  */
 int AK_get_view_obj_id(char *name) {
@@ -31,12 +59,11 @@ int AK_get_view_obj_id(char *name) {
     
     struct list_node *row;
     AK_PRO;
-    //while ((row = (AK_list*)AK_get_row(i++, "AK_view"))) {
     while ((row = (struct list_node*)AK_get_row(i++, "AK_view"))) {
         struct list_node *name_elem = AK_GetNth_L2(2,row);
         if (!strcmp(name_elem->data, name)) {
             memcpy(&id, row->next->data, sizeof(int));
-	    AK_EPI;
+	        AK_EPI;
             return id;
         }
     }
@@ -47,12 +74,12 @@ int AK_get_view_obj_id(char *name) {
 /**
  * @author Danko Sačer
  * @brief Function that returns a query by its name
- * @param name name of the view
+ * @param name Name of the view
  * @return query string or EXIT_ERROR
  */
 char* AK_get_view_query(char *name){
-   int i = 0;
-   char *query;
+	int i = 0;
+	char *query;
     
     struct list_node *row;
     AK_PRO;
@@ -73,19 +100,18 @@ char* AK_get_view_query(char *name){
 /**
  * @author Danko Sačer
  * @brief Function that returns a relation expression by its name
- * param name name of the view
+ * param name Name of the view
  * @return rel_exp string or EXIT_ERROR
  */
 char* AK_get_rel_exp(char *name){
-   int i = 0;
-   char *rel_exp;
+	int i = 0;
+	char *rel_exp;
    
-    struct list_node *row;
-    AK_PRO;
+	struct list_node *row; AK_PRO;
 
-    while ((row = (struct list_node*)AK_get_row(i++, "AK_view"))) {
-        struct list_node *name_elem = AK_GetNth_L2(2,row);
-        if (!strcmp(name_elem->data, name)) {
+	while ((row = (struct list_node*)AK_get_row(i++, "AK_view"))) {
+		struct list_node *name_elem = AK_GetNth_L2(2,row);
+		if (!strcmp(name_elem->data, name)) {
             struct list_node *rel_exp_elem = AK_GetNth_L2(3,row);
             rel_exp = rel_exp_elem->data;
 	    AK_EPI;
@@ -95,6 +121,7 @@ char* AK_get_rel_exp(char *name){
     AK_EPI;
     return (char*)(EXIT_ERROR);
 }
+
 
 /**
  * @author Kresimir Ivkovic
@@ -107,26 +134,26 @@ char* AK_get_rel_exp(char *name){
  * @return Id of the newly inserted view
  */
 int AK_view_add(char *name, char *query, char *rel_exp, int set_id){
-    char *tblName = "AK_view";
-    AK_PRO;
+	char *tblName = "AK_view";
+	AK_PRO;
 
     struct list_node *row_root = (struct list_node *) AK_malloc(sizeof (struct list_node));
     AK_Init_L3(&row_root);
     
     int view_id = AK_get_id();
-    if(set_id!=0) view_id = set_id;
+    if(set_id!=0)
+        view_id = set_id;
     AK_Insert_New_Element(TYPE_INT, &view_id, tblName, "obj_id", row_root);
-
-    //adding prefics '_view' to view name for integration of view relation expression (used in query_optimization.c for now) by Danko Sacer NOT SET
-    //char set_name[strlen(name)];
-    //strcpy(set_name, name);
-    //strcat(set_name, "_view");
     AK_Insert_New_Element(TYPE_VARCHAR, name, tblName, "name", row_root);
     AK_Insert_New_Element(TYPE_VARCHAR, query, tblName, "query", row_root);
     AK_Insert_New_Element(TYPE_VARCHAR, rel_exp, tblName, "rel_exp", row_root);
+    if(AK_check_view_name(name) == EXIT_ERROR){
+        AK_EPI;
+        return EXIT_ERROR;
+    }
     AK_insert_row(row_root);
     AK_EPI;
-    return view_id;
+    return view_id;  
 }
 
 /**
@@ -159,16 +186,16 @@ int AK_view_remove_by_obj_id(int obj_id) {
  * @return error or success
  */
 int AK_view_rename(char *name, char *new_name){
-   int result = 0, i = 0;
-   int view_id;
-   char *query;
-   char *rel_exp;
+	int result = 0, i = 0;
+	int view_id;
+	char *query;
+	char *rel_exp;
    
-   struct list_node *row;
-   AK_PRO;
-   
-   while ((row = (struct list_node *)AK_get_row(i++, "AK_view"))) {
-       struct list_node *name_elem = AK_GetNth_L2(2,row);
+	struct list_node *row;
+	AK_PRO;
+	
+	while ((row = (struct list_node *)AK_get_row(i++, "AK_view"))) {
+		struct list_node *name_elem = AK_GetNth_L2(2,row);
         if (!strcmp(name_elem->data, name)) {
             struct list_node *view_elem = AK_GetNth_L2(1,row);
             struct list_node *query_rel_exp_elem = AK_GetNth_L2(3,row);
@@ -177,12 +204,14 @@ int AK_view_rename(char *name, char *new_name){
 	    rel_exp = query_rel_exp_elem->data;
         }
     }
-
-   result = AK_view_remove_by_name(name);
-   result = AK_view_remove_by_name(name);
-   result = AK_view_add(new_name, query, rel_exp, view_id);
-   AK_EPI;
-   return result;
+    if(AK_check_view_name(new_name) == EXIT_ERROR){
+        AK_EPI;
+        return EXIT_ERROR;
+    }
+	result = AK_view_remove_by_name(name);
+	result = AK_view_add(new_name, query, rel_exp, view_id);
+	AK_EPI;
+	return result;
 }
 
 /**
@@ -193,33 +222,33 @@ int AK_view_rename(char *name, char *new_name){
  * @return Result of AK_view_remove_by_obj_id or EXIT_ERROR if no id is found
  */
 int AK_view_remove_by_name(char *name) {
-   AK_PRO;
+	AK_PRO;
     
     struct list_node *row_root = (struct list_node *) AK_malloc(sizeof (struct list_node));
     AK_Init_L3(&row_root);
     
-   AK_Update_Existing_Element(TYPE_VARCHAR, name, "AK_view", "name", row_root);
-   int result = AK_delete_row(row_root);
-   AK_EPI;
-   return result;
+	AK_Update_Existing_Element(TYPE_VARCHAR, name, "AK_view", "name", row_root);
+	int result = AK_delete_row(row_root);
+	AK_EPI;
+	return result;
 }
 
 /**
  * @author Kresimir Ivkovic
- * @brief Function that changes the query from a view (determined by it's name) to "query"
+ * @brief Function that changes the query from a view (determined by its name) to "query"
  * @param name of the query
  * @param query new query of the view
  * @param rel_exp relation expression of the view
  * @return error or success
  */
 int AK_view_change_query(char *name, char *query, char *rel_exp){
-   AK_PRO;
-   int view_id = AK_get_view_obj_id(name);
+	AK_PRO;
+	int view_id = AK_get_view_obj_id(name);
 
-   int result = AK_view_remove_by_name(name);
-   result = AK_view_add(name, query, rel_exp, view_id);
-   AK_EPI;
-   return result;
+	int result = AK_view_remove_by_name(name);
+	result = AK_view_add(name, query, rel_exp, view_id);
+	AK_EPI;
+	return result;
 }
 
 /**
@@ -254,47 +283,47 @@ int AK_test_get_view_data(char *rel_exp){
 			}
 		}		 
 		
-        }
+	}
 	int sel1 = AK_selection(srcTable, destTable, expr);
 }
+
 
 /**
  * @author Kresimir Ivkovic, updated by Lidija Lastavec
  * @brief A testing function for view.c functions.
  */
 TestResult AK_view_test() {
-   AK_PRO;
+	AK_PRO;
 
     int passed=0;
     int failed=0;
 
-   printf("\n*******VIEW TESTS**********\n\n");
+	printf("\n*******VIEW TESTS**********\n\n");
 
-   AK_view_add("view1", "SELECT lastname FROM profesor","profesor;lastname;", 0);
-   printf ("\n\n");
-   AK_view_add("view2", "query2","firstname;", 0);
-      printf ("\n\n");
+	AK_view_add("view1", "SELECT lastname FROM profesor","profesor;lastname;", 0);
+	printf ("\n\n");
+	AK_view_add("view2", "query2","firstname;", 0);
+    printf ("\n\n");
 
-   AK_view_add("view3", "query3","*;profesor;", 0);
-      printf ("\n\n");
+	AK_view_add("view3", "query3","*;profesor;", 0);
+	printf ("\n\n");
 
-   AK_view_add("view4", "query4","2 >;", 0);
-      printf ("\n\n");
+	AK_view_add("view4", "query4","2 >;", 0);
+	printf ("\n\n");
 
-   AK_view_add("view5", "select * from student where firstname=Robert",
-   "student;firstname;Robert;=", 0);
-      printf ("\n\n");
+	AK_view_add("view5", "select * from student where firstname=Robert", "student;firstname;Robert;=", 0);
+	printf ("\n\n");
 
-   AK_view_add("view6", "query6","lastname", 0);
-      printf ("\n\n");
+	AK_view_add("view6", "query6","lastname", 0);
+	printf ("\n\n");
 
-   AK_view_add("view7", "query7","student;firstname", 0);
-      printf ("\n\n");
+	AK_view_add("view7", "query7","student;firstname", 0);
+	printf ("\n\n");
 
-   AK_print_table("AK_view");
+	AK_print_table("AK_view");
 
-   printf("Obj_id for view1: %d\n", AK_get_view_obj_id("view1"));
-   printf("Query for view1: %s\n\n", AK_get_view_query("view1"));
+	printf("Obj_id for view1: %d\n", AK_get_view_obj_id("view1"));
+	printf("Query for view1: %s\n\n", AK_get_view_query("view1"));
 
    printf("Obj_id for view2: %d\n", AK_get_view_obj_id("view2"));
    printf("Query for view2: %s\n\n", AK_get_view_query("view2"));
@@ -323,66 +352,71 @@ TestResult AK_view_test() {
         }
 
     printf("\n****TEST 2 - DELETE VIEW BY ID**** \n");
-    printf("\nDeleting views 'view2' and 'view6' by Obj_id...\n");
-   printf("Obj_id for view2: %d\n", AK_get_view_obj_id("view2"));
-   printf("Obj_id for view6: %d\n", AK_get_view_obj_id("view6")); 
+	printf("\nDeleting views 'view2' and 'view6' by Obj_id...\n");
+	printf("Obj_id for view2: %d\n", AK_get_view_obj_id("view2"));
+	printf("Obj_id for view6: %d\n", AK_get_view_obj_id("view6")); 
     int delete3=AK_view_remove_by_obj_id(AK_get_view_obj_id("view2"));
-   int delete4= AK_view_remove_by_obj_id(AK_get_view_obj_id("view6"));   
-   if (delete3 != EXIT_ERROR && delete4 != EXIT_ERROR) {
-        passed++;
-    AK_print_table("AK_view");
-    printf("\n Test 2 is successful!\n\n");
-
-    }else {
+	int delete4= AK_view_remove_by_obj_id(AK_get_view_obj_id("view6"));   
+	if (delete3 != EXIT_ERROR && delete4 != EXIT_ERROR) {
+		passed++;
+		AK_print_table("AK_view");
+		printf("\n Test 2 is successful!\n\n");
+	}else {
         failed ++;
         printf("\n Test 2 failed!\n\n");
         }
+        
+        
+	printf("\n **** TEST 3 - RENAME VIEW ****\n");
+	printf("\nRenaming 'view3' to 'view300'...\n");
+	int renameView = AK_view_rename("view3","view300");
+	if (renameView != EXIT_ERROR) {
+		passed++;
+		AK_print_table("AK_view");
+		printf("\n Test 3 is successful!\n\n");
+	}else {
+		failed ++;
+        AK_print_table("AK_view");
+		printf("\n Test 3 failed!\n\n");
+	}
 
 
-  
-   printf("\n **** TEST 3 - RENAME VIEW ****\n");
+	printf("\n **** TEST 4 - CHANGE QUERY ****\n");
+	printf("\nChanging 'view4' query to '44query44'...\n");
+	int changeQuery= AK_view_change_query("view4","44query44","student;id");
+	if (changeQuery != EXIT_ERROR) {
+		passed++;
+		AK_print_table("AK_view");
+		printf("\n Test 4 is successful!\n\n");
+	}else {
+		failed ++;
+		printf("\n Test 4 failed!\n\n");
+	}
 
-   printf("\nRenaming 'view3' to 'view300'...\n");
-   int renameView = AK_view_rename("view3","view300");
-     if (renameView != EXIT_ERROR) {
-        passed++;
+	printf("\n **** TEST 5 - SHOW VIEW DATA ****\n");   
+	printf("\n Show test view data for view5'...\n");
+	int showData = AK_test_get_view_data("student;firstname;Robert;=");
+	if (showData != EXIT_ERROR) {
+		passed++;
+		AK_print_table("AK_view");
+		printf("\n Test 5 is successful!\n\n");
+	}else {
+		failed ++;
+		printf("\n Test 5 failed!\n\n");
+	}
+
+    printf("\n **** TEST 6 - ADD VIEW WITH EXISTING NAME ****\n");   
+	printf("\n Checking if name 'view4' already exists...\n");
+	int *addResult = AK_view_add("view4", "test","*;profesor;", 0);
+	if (addResult == EXIT_ERROR) {
+		passed++;
+        printf("\n Name already exists! View not added.");
+		printf("\n Test 6 is successful!\n\n");
+	}else {
+		failed ++;
+		printf("\n Test 6 failed!\n\n");
+	}
     AK_print_table("AK_view");
-    printf("\n Test 3 is successful!\n\n");
-
-    }else {
-        failed ++;
-        printf("\n Test 3 failed!\n\n");
-        }
-
-
-   printf("\n **** TEST 4 - CHANGE QUERY ****\n");
-
-   printf("\nChanging 'view4' query to '44query44'...\n");
-   int changeQuery= AK_view_change_query("view4","44query44","student;id");
-   if (changeQuery != EXIT_ERROR) {
-        passed++;
-    AK_print_table("AK_view");
-    printf("\n Test 4 is successful!\n\n");
-
-    }else {
-        failed ++;
-        printf("\n Test 4 failed!\n\n");
-        }
-
-printf("\n **** TEST 5 - SHOW VIEW DATA ****\n");   
-printf("\n Show test view data for view5'...\n");
-int showData = AK_test_get_view_data("student;firstname;Robert;=");
-   if (showData != EXIT_ERROR) {
-        passed++;
-    AK_print_table("AK_view");
-    printf("\n Test 5 is successful!\n\n");
-
-    }else {
-        failed ++;
-        printf("\n Test 5 failed!\n\n");
-        }
-
-AK_EPI;
-
-   return TEST_result(passed,failed);
+	AK_EPI;
+	return TEST_result(passed,failed);
 }

--- a/akdb/src/sql/view.h
+++ b/akdb/src/sql/view.h
@@ -87,4 +87,12 @@ char* AK_get_view_query(char *name);
 char* AK_get_rel_exp(char *name);
 
 
+/**
+ * @author Sara Kisic
+ * @brief Function that checks if the name of the view already exists in AK_view table
+ * @param name Name of the view
+ * @return EXIT_ERROR if the name already exists or name
+ */
+char* AK_check_view_name(char *name)
+
 #endif


### PR DESCRIPTION
Ispravljene gramatičke greške i maknuti suvišni komentari iz koda, dodana provjera postojanja imena view-a (funkcija AK_check_view_name), funkcija ubačena u funkcije za dodavanje pogleda (AK_view_add) i za preimenovanje pogleda (AK_view_rename). U ostalim djelovima koda, funkcije same vraćaju EXIT_ERROR ukoliko ime pogleda ne postoji. Maknuti suvišne linije iz select.h i select.c